### PR TITLE
Remove react-native as a peer dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,9 +30,6 @@
   "dependencies": {
     "react-tween-state": "0.0.5"
   },
-  "peerDependencies": {
-    "react-native": ">= 0.4.0"
-  },
   "devDependencies": {
     "babel-core": "5.4.7",
     "jest-cli": "0.4.5",


### PR DESCRIPTION
I'm trying to incorporate this package into my app, but I'm running into semver hell:

```
npm ERR! peerinvalid The package react-native@0.10.0 does not satisfy its siblings' peerDependencies requirements!
npm ERR! peerinvalid Peer react-native-progress-hud@1.0.2 wants react-native@>= 0.4.0
```

At first glance this should work. But semver doesn't seem to handle 0.x.x versions well:
http://www.jongleberry.com/semver-has-failed-us.html

I'm proposing to remove the peer dependency on react-native, at least until semver starts doing the right thing.
