### PR TITLE
Make it work with RN 0.26.*

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -49,7 +49,7 @@ var ProgressHUD = React.createClass({
   mixins: [tweenState.Mixin],
 
   contextTypes: {
-    showProgressHUD: React.PropTypes.func.isRequired,
+    showProgressHUD: React.PropTypes.func,
     dismissProgressHUD: React.PropTypes.func
   },
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,15 +1,13 @@
 'use strict';
 
-var React = require('react-native');
-var tweenState = require('react-tween-state');
-
 var {
   Image,
   StyleSheet,
   TouchableHighlight,
   View
-} = React;
-
+} = require('react-native');
+var React = require('react');
+var tweenState = require('react-tween-state');
 var styles = require('./styles');
 var images = require('./images');
 


### PR DESCRIPTION
## What is it?

Change the way to import React and React-native
## Why?

RN 0.26.0 changed the namespace of react stuff
